### PR TITLE
Searching Overhaul

### DIFF
--- a/app/src/main/java/wigleyd/witroomfinder/ClassDetailsActivity.java
+++ b/app/src/main/java/wigleyd/witroomfinder/ClassDetailsActivity.java
@@ -61,7 +61,6 @@ public class ClassDetailsActivity extends Activity {
             }else {
                 tv.setBackgroundResource(R.color.white);
             }
-            System.out.println("Loop: " + i + " Adding: " + timeResultsList.get(i).toString() + " to list");
             tv.setText(timeResultsList.get(i).toString());
             tv.setPadding(0, PADDING, 0, PADDING);
             tv.setTag(i);

--- a/app/src/main/java/wigleyd/witroomfinder/ClassDetailsActivity.java
+++ b/app/src/main/java/wigleyd/witroomfinder/ClassDetailsActivity.java
@@ -42,9 +42,9 @@ public class ClassDetailsActivity extends Activity {
         rawResultsList = myHandler.getDetailedRooms();
         ArrayList timeResultsList = getTrimmedResults(rawResultsList);
         //My print statement to get the raw list of results. Used for debugging.
-        for (int i =0; i <rawResultsList.size(); i++) {
-            System.out.println("The raw list is: " + rawResultsList.get(i).toString());
-        }
+//        for (int i =0; i <rawResultsList.size(); i++) {
+//            System.out.println("The raw list is: " + rawResultsList.get(i).toString());
+//        }
         timeResultsList = getOrderedLists(timeResultsList);
         ScrollView sv = new ScrollView(this);
         LinearLayout ll = new LinearLayout(this);

--- a/app/src/main/java/wigleyd/witroomfinder/ClassDetailsActivity.java
+++ b/app/src/main/java/wigleyd/witroomfinder/ClassDetailsActivity.java
@@ -42,9 +42,9 @@ public class ClassDetailsActivity extends Activity {
         rawResultsList = myHandler.getDetailedRooms();
         ArrayList timeResultsList = getTrimmedResults(rawResultsList);
         //My print statement to get the raw list of results. Used for debugging.
-//        for (int i =0; i <rawResultsList.size(); i++) {
-//            System.out.println("The raw list is: " + rawResultsList.get(i).toString());
-//        }
+        for (int i =0; i <rawResultsList.size(); i++) {
+            System.out.println("The raw list is: " + rawResultsList.get(i).toString());
+        }
         timeResultsList = getOrderedLists(timeResultsList);
         ScrollView sv = new ScrollView(this);
         LinearLayout ll = new LinearLayout(this);

--- a/app/src/main/java/wigleyd/witroomfinder/Keywords.java
+++ b/app/src/main/java/wigleyd/witroomfinder/Keywords.java
@@ -26,9 +26,9 @@ public class Keywords {
 	//essential
 	String[] regex = {"WIT	", "ENGR", "LITR"};
 
-	//stuff that used to be in the regex
-	String[] specificProblems = {"COOP EDUCATION 1:", "COOP EDUCATION 2:", "VISUALIZATION 3:", "CAD 2:", "VISUAL PERCEPTION OF THE CITY:",
-			"MYTH AMERICA:", "VISUALIZATION 2: ADV PRSPECTIV", "CAD 1: SURSURFACE MODELING\tT", "DESIGN PERSP: TOPICS IN HISTOR"};
+//	//stuff that used to be in the regex. Dont need it anymore, will chop once I'm sure
+//	String[] specificProblems = {"COOP EDUCATION 1:", "COOP EDUCATION 2:", "VISUALIZATION 3:", "CAD 2:", "VISUAL PERCEPTION OF THE CITY:",
+//			"MYTH AMERICA:", "VISUALIZATION 2: ADV PRSPECTIV", "CAD 1: SURSURFACE MODELING\tT", "DESIGN PERSP: TOPICS IN HISTOR"};
 
 	String[] mondayCases = {"	M	","	MT", "	MW", "	MR", "	MF"};
 

--- a/app/src/main/java/wigleyd/witroomfinder/Keywords.java
+++ b/app/src/main/java/wigleyd/witroomfinder/Keywords.java
@@ -25,7 +25,7 @@ public class Keywords {
 	
 	//essential
 	String[] regex = {"WIT	", "COOP EDUCATION 1:", "COOP EDUCATION 2:", "VISUALIZATION 3:", "CAD 2:", "VISUAL PERCEPTION OF THE CITY:",
-			"MYTH AMERICA:", "ENGR"};
+			"MYTH AMERICA:", "ENGR", "LITR", "VISUALIZATION 2: ADV PRSPECTIV", "CAD 1: SURFACE MODELING\tT", "DESIGN PERSP: TOPICS IN HISTOR"};
 
 	String[] mondayCases = {"	M	","	MT", "	MW", "	MR", "	MF"};
 

--- a/app/src/main/java/wigleyd/witroomfinder/Keywords.java
+++ b/app/src/main/java/wigleyd/witroomfinder/Keywords.java
@@ -24,13 +24,16 @@ public class Keywords {
 	String[] blank = {""};//should actually serve a purpose not actually garbage
 	
 	//essential
-	String[] regex = {"WIT	", "COOP EDUCATION 1:", "COOP EDUCATION 2:", "VISUALIZATION 3:", "CAD 2:", "VISUAL PERCEPTION OF THE CITY:",
-			"MYTH AMERICA:", "ENGR", "LITR", "VISUALIZATION 2: ADV PRSPECTIV", "CAD 1: SURFACE MODELING\tT", "DESIGN PERSP: TOPICS IN HISTOR"};
+	String[] regex = {"WIT	", "ENGR", "LITR"};
+
+	//stuff that used to be in the regex
+	String[] specificProblems = {"COOP EDUCATION 1:", "COOP EDUCATION 2:", "VISUALIZATION 3:", "CAD 2:", "VISUAL PERCEPTION OF THE CITY:",
+			"MYTH AMERICA:", "VISUALIZATION 2: ADV PRSPECTIV", "CAD 1: SURSURFACE MODELING\tT", "DESIGN PERSP: TOPICS IN HISTOR"};
 
 	String[] mondayCases = {"	M	","	MT", "	MW", "	MR", "	MF"};
 
 	String[] tuesdayCases = {"	MT", "	T	",  "	TW", "TR	","TF	"};
-	String[] wednesdayCases = {"	W	", "	MW", "TW", "	WR", "	WRF	"};
+	String[] wednesdayCases = {"	W	", "	MW", "	MTW", "	TW", "	WR", "	WRF	"};
 	String[] thursdayCases = {"R	", "RF"};
 	String[] fridayCases = {"F	"}; //this will pick up last names that end with F well see how big that is.
 	public String[] getKeywords(){

--- a/app/src/main/java/wigleyd/witroomfinder/Search.java
+++ b/app/src/main/java/wigleyd/witroomfinder/Search.java
@@ -101,9 +101,7 @@ public class Search {
 					time2 = Character.toString(secondTime[1]);
 				}
 				//System.out.println("I'm on this entry: " + conflictList.get(i).toString());
-				System.out.println("The current entry is: " + currentEntry);
 
-				System.out.println(time2);
 				int startHour = Integer.parseInt(time);
 				int endHour = Integer.parseInt(time2);
 				int delta = (endHour - startHour);

--- a/app/src/main/java/wigleyd/witroomfinder/Search.java
+++ b/app/src/main/java/wigleyd/witroomfinder/Search.java
@@ -36,6 +36,7 @@ public class Search {
 				conflictList.set(i, conflictList.get(i).toString().replace(keys[j], ""));
 			}
 		}
+		conflictList = trimUpToDay(conflictList);
 	}
 
 	public void skipTimeSearch() {
@@ -158,6 +159,65 @@ public class Search {
 				tripped = false;
 			}
 		}
+	}
+
+	/**
+	 * Method that will be responsible for trimming all the course registration data until it reaches the day
+	 * which is when I start caring about what it says. Basically everything before that is junk.
+	 */
+	private ArrayList trimUpToDay(ArrayList originalList) {
+		ArrayList trimmedList = new ArrayList();
+		Keywords keywords = new Keywords();
+		String[] currentSearch = null;
+		boolean shouldBreak = false;
+		final int DAYS_IN_WEEK =5;
+		for (int i =0; i <originalList.size(); i++) {
+			String currentString = originalList.get(i).toString();
+			String newString = null;
+
+			for (int j=0; j < DAYS_IN_WEEK; j++) {
+				if (j==0) {
+					currentSearch = keywords.mondayCases;
+				}else if (j==1) {
+					currentSearch = keywords.tuesdayCases;
+				}else if (j==2) {
+					currentSearch = keywords.wednesdayCases;
+				}else if (j==3) {
+					currentSearch = keywords.thursdayCases;
+				}else if (j==4) {
+					currentSearch = keywords.fridayCases;
+				}
+				for (int caseNum = 0; caseNum < currentSearch.length; caseNum++){
+					//I think I could technically replace this conditional with the first code block
+					//inside it but I'm reluctant to do that so I'm keeping it how it is.
+					if (currentString.contains(currentSearch[caseNum])){
+						//gets the index where we find the string.
+						int index = currentString.indexOf(currentSearch[caseNum]);
+						//trim up to where the day is stated
+						newString = currentString.substring(index);
+						shouldBreak = true;
+						break;
+					}
+				}
+				//trying to break from more for loops so this doesn't take forever.
+				if (shouldBreak) {
+					shouldBreak = false;
+					break;
+				}
+			}
+			//System.out.println("Orig entry was: " + currentString);
+			//System.out.println("New entry is: " + newString);
+
+			//If the entry was garbage or had a TBA day I'm not going to add it because its junk anyways. I cant find a
+			//room for a class that doesnt exist or has a TBD meeting day
+			if (newString != null) {
+				trimmedList.add(newString);
+			}
+
+
+		}
+
+		return trimmedList;
 	}
 
 	/**

--- a/app/src/main/java/wigleyd/witroomfinder/Search.java
+++ b/app/src/main/java/wigleyd/witroomfinder/Search.java
@@ -100,7 +100,9 @@ public class Search {
 					time2 = Character.toString(secondTime[1]);
 				}
 				//System.out.println("I'm on this entry: " + conflictList.get(i).toString());
+				System.out.println("The current entry is: " + currentEntry);
 
+				System.out.println(time2);
 				int startHour = Integer.parseInt(time);
 				int endHour = Integer.parseInt(time2);
 				int delta = (endHour - startHour);


### PR DESCRIPTION
Changed the search logic to be more resistant to errors in the future. I basically trim all the entries up until where the day is listed initially. It may require more cycles, BUT this is better because it saves me from flagging specific class names that break the searching. Plus it may have reached a point where going through all those class names actually took longer than trimming the entries.

Also protects searching from all conflicts with the names of classes in future semesters.
